### PR TITLE
Show episodes in cronological order

### DIFF
--- a/app/ui/EpisodesPage.qml
+++ b/app/ui/EpisodesPage.qml
@@ -736,7 +736,7 @@ Page {
 
         var db = Podcasts.init();
         db.transaction(function (tx) {
-            var rs = tx.executeSql("SELECT rowid, * FROM Episode WHERE podcast=? ORDER BY published DESC", [pid]);
+            var rs = tx.executeSql("SELECT rowid, * FROM Episode WHERE podcast=? ORDER BY published", [pid]);
             for(i = 0; i < rs.rows.length; i++) {
                 episode = rs.rows.item(i);
                 if (!episode.listened) {


### PR DESCRIPTION
By default, podbird/podphoenix show episodes in reverse cronological order:

```
738        db.transaction(function (tx) {
739            var rs = tx.executeSql("SELECT rowid, * FROM Episode WHERE podcast=? ORDER BY published DESC", [pid]);
```

I recommend showing episodes in cronological order by default:

![](https://i.imgur.com/Hu2uO1R.jpg)

A toggle to show episodes in reverse cronological order could be added later.