### PR TITLE
Auto-clean listened episodes

### DIFF
--- a/app/podcasts.js
+++ b/app/podcasts.js
@@ -401,7 +401,11 @@ function cleanUp(today, retentionDays) {
             var rs2 = tx.executeSql("SELECT rowid, * FROM Episode WHERE podcast=?", [rs.rows.item(i).rowid]);
             for (var j=0; j< rs2.rows.length; j++) {
                 var diff = Math.floor((today - rs2.rows.item(j).published)/dayToMs)
-                if (rs2.rows.item(j).downloadedfile && diff > retentionDays) {
+                var item = rs2.rows.item(j);
+                if (!item.favourited && item.downloadedfile && (
+                    diff > retentionDays
+                    || (podphoenix.settings.deleteListened && item.listened)
+                )) {
                     fileManager.deleteFile(rs2.rows.item(j).downloadedfile)
                     tx.executeSql("UPDATE Episode SET downloadedfile = NULL WHERE guid = ?", [rs2.rows.item(j).guid]);
                 }

--- a/app/podphoenix.qml
+++ b/app/podphoenix.qml
@@ -122,6 +122,7 @@ MainView {
         property bool firstRun: true
         property int maxEpisodeDownload: -1
         property bool hideListened: false
+        property bool deleteListened: false
         property bool showListView: true
         property int skipForward: 30
         property int skipBack: 10
@@ -387,6 +388,12 @@ MainView {
                 console.log("[LOG]: End of Media. Stopping.")
                 endOfMedia = true
                 stop()
+
+                Podcasts.init().transaction(function(tx) {
+                    // Playlist finished, mark all playlist as played.
+                    tx.executeSql("UPDATE Episode SET listened=1 WHERE guid in (SELECT guid FROM Queue)");
+                    refreshModels();
+                })
             }
         }
 

--- a/app/ui/SettingsPage.qml
+++ b/app/ui/SettingsPage.qml
@@ -268,6 +268,23 @@ Page {
                 onClicked: mainStack.push(Qt.resolvedUrl("../settings/DownloadSetting.qml"))
             }
 
+            ListItem {
+                ListItemLayout {
+                    id: deleteListened
+                    title.text: i18n.tr("Automatically delete listened episodes")
+                    title.color: podphoenix.appTheme.baseText
+                    summary.text: i18n.tr("Automatically delete listened episodes on application start")
+                    summary.color: podphoenix.appTheme.baseSubText
+                    Switch {
+                        SlotsLayout.position: SlotsLayout.Last
+                        checked: podphoenix.settings.deleteListened
+                        onClicked: podphoenix.settings.deleteListened = checked
+                    }
+                }
+                divider.visible: false
+                height: deleteListened.height
+            }
+
  	ListItem {
                 ListItemLayout {
                     id: downloadWifiOnlyLayout


### PR DESCRIPTION
I had this set of local changes which I have been using for some time and which I keep rebasing.
I'm submitting this PR in hope I'm not alone not liking the manual maintenance of episodes.

* Exclude favorites episodes from cleanup (might deserve a setting).
* Auto-mark queued episodes as played on playlist end.
* Setting to toggle auto-delete played episodes during daily download cleanup.

Note: Since the app isn't running in background, it does not catch events about track change from the mediaplayer service when it is out of focus. However, the end of playlist event appears to always trigger when the app gets the focus back, thus this less-than-optimal choice of relying on playlist end events.