### PR TITLE
fix query for available Podcasts

### DIFF
--- a/app/ui/PodcastsTab.qml
+++ b/app/ui/PodcastsTab.qml
@@ -271,11 +271,10 @@ Page {
         db.transaction(function (tx) {
             podcastModel.clear();
             var rs = tx.executeSql(`
-                SELECT p.rowid as rowid, p.*, COUNT(e.rowid) as episodeCount
+                SELECT p.rowid as rowid, p.*, sum(CASE WHEN e.listened = 0 THEN 1 ELSE 0 END) as episodeCount
                 FROM Podcast as p
                 JOIN Episode as e
                 ON p.rowid = e.podcast
-                WHERE e.listened = 0
                 GROUP BY p.rowid
                 ORDER BY p.name ASC
             `);


### PR DESCRIPTION
The original query introduced in 16fe00d did not list a podcast with fully listened to episodes.

The SQL query has been changed to sum instead of filter for listened.

Fixes #19 and #20