### PR TITLE
fix episode fetch crashing on redirects

### DIFF
--- a/app/podcasts.js
+++ b/app/podcasts.js
@@ -239,6 +239,18 @@ function updateEpisodes(refreshModel) {
                 xhr[i].open("GET", url);
                 xhr[i].onreadystatechange = function() {
                     if (xhr[i].readyState === XMLHttpRequest.DONE) {
+                        const location = xhr[i].getResponseHeader('Location');
+                        if (location) {
+                            // for some reason a 302 will also include anything that was
+                            // returned in the original redirect in the body, breaking XML
+                            // just re-launch the request with the new location
+                            const newXhr = new XMLHttpRequest();
+                            newXhr.open("GET", location);
+                            newXhr.onreadystatechange = xhr[i].onreadystatechange;
+                            newXhr.send();
+                            xhr[i] = newXhr;
+                            return;
+                        }
                         xhrComplete[i] = true;
 
                         try {

--- a/app/ui/SearchPage.qml
+++ b/app/ui/SearchPage.qml
@@ -394,6 +394,15 @@ Page {
         xhr.open("GET", feedUrl);
         xhr.onreadystatechange = function() {
             if (xhr.readyState === XMLHttpRequest.DONE) {
+                const location = xhr.getResponseHeader('Location');
+                if (location) {
+                    // for some reason a 302 will also include anything that was
+                    // returned in the original redirect in the body, breaking XML
+                    // just re-launch the request with the new location
+                    getPodcastDescription(location, index);
+                    return;
+                }
+
                 var e = xhr.responseXML.documentElement;
                 for(var h = 0; h < e.childNodes.length; h++) {
                     if(e.childNodes[h].nodeName === "channel") {


### PR DESCRIPTION
For some reason a 302 will also include anything that was returned in the original redirect in the body, breaking XML. This re-launches the request with the new url to avoid that.

Fixes #20 (for sure this time :D)