### PR TITLE
Ensure certain podcasts have episode names and info; fixes #41

### DIFF
--- a/app/podcasts.js
+++ b/app/podcasts.js
@@ -262,40 +262,84 @@ function updateEpisodes(refreshModel) {
                                         if(c.childNodes[j].nodeName === "item") {
                                             var t = c.childNodes[j];
                                             var track = {}
+                                            // Debug: log first item's structure
+                                            if (j < 2) {
+                                                console.log("[DEBUG] Parsing item " + j);
+                                            }
                                             for(var k = 0; k < t.childNodes.length; k++) {
                                                 try {
-                                                    var nodeName = t.childNodes[k].nodeName.toLowerCase();
-                                                    if (nodeName === "title")               track['name'] = t.childNodes[k].childNodes[0].nodeValue;
-                                                    else if (nodeName === "description")    track['description'] = t.childNodes[k].childNodes[0].nodeValue;
-                                                    else if (nodeName === "guid")           track['guid'] = t.childNodes[k].childNodes[0].nodeValue;
-                                                    else if (nodeName === "pubdate")        track['published'] = new Date(t.childNodes[k].childNodes[0].nodeValue).getTime();
-                                                    else if (nodeName === "duration") {
-                                                        var dur = t.childNodes[k].childNodes[0].nodeValue.split(":");
-                                                        if (dur.length === 1) {
-                                                            track['duration'] = parseInt(dur[0]);
-                                                        } else if (dur.length === 2) {
-                                                            track['duration'] = parseInt(dur[0]) * 60 + parseInt(dur[1]);
-                                                        } else if (dur.length === 3) {
-                                                            track['duration'] = parseInt(dur[0]) * 3600 + parseInt(dur[1]) * 60 + parseInt(dur[2]);
+                                                        var node = t.childNodes[k];
+                                                        var nodeName = (node.localName ? node.localName : node.nodeName).toLowerCase();
+                                                        // Debug: log node info for first item
+                                                        if (j < 1 && nodeName && nodeName !== "#text") {
+                                                            console.log("[DEBUG] Node " + k + ": nodeName=" + node.nodeName + ", localName=" + node.localName + ", computed=" + nodeName);
                                                         }
-                                                    } else if (nodeName === "enclosure") {
-                                                        var el = t.childNodes[k];
-                                                        for (var l = 0; l < el.attributes.length; l++) {
-                                                            if(el.attributes[l].nodeName === "url")         track['audiourl'] = el.attributes[l].nodeValue;
+                                                        // Helper to get text content - iterate all child nodes to find text/CDATA
+                                                        var getTextContent = function(n) {
+                                                            var text = "";
+                                                            if (n.childNodes) {
+                                                                for (var m = 0; m < n.childNodes.length; m++) {
+                                                                    var child = n.childNodes[m];
+                                                                    // Debug: log child node info for first item's title
+                                                                    if (j < 1 && nodeName === "title") {
+                                                                        console.log("[DEBUG] Title child " + m + ": nodeType=" + child.nodeType + ", nodeName=" + child.nodeName + ", value='" + (child.nodeValue || "").substring(0, 30) + "'");
+                                                                    }
+                                                                    // nodeType 3 = TEXT_NODE, nodeType 4 = CDATA_SECTION_NODE
+                                                                    // Also check nodeName for #text and #cdata-section as fallback
+                                                                    if (child.nodeType === 3 || child.nodeType === 4 ||
+                                                                        child.nodeName === "#text" || child.nodeName === "#cdata-section") {
+                                                                        text += child.nodeValue || "";
+                                                                    }
+                                                                }
+                                                            }
+                                                            return text.trim();
+                                                        };
+                                                        // Accept common variants and namespaced tags (eg. itunes:subtitle/summary)
+                                                        if (nodeName === "title" && !track['name']) {
+                                                            track['name'] = getTextContent(node);
+                                                            if (j < 1) console.log("[DEBUG] Got title: " + track['name']);
                                                         }
+                                                        else if ((nodeName === "description" || nodeName === "summary" || nodeName === "subtitle") && !track['description']) {
+                                                            track['description'] = getTextContent(node);
+                                                            if (j < 1) console.log("[DEBUG] Got description (first 50 chars): " + (track['description'] || "").substring(0, 50));
+                                                        }
+                                                        else if (nodeName === "guid")           track['guid'] = getTextContent(node);
+                                                        else if (nodeName === "pubdate")        track['published'] = getTextContent(node) ? new Date(getTextContent(node)).getTime() : undefined;
+                                                        else if (nodeName === "duration") {
+                                                            var durRaw = getTextContent(node);
+                                                            if (durRaw) {
+                                                                var dur = durRaw.split(":");
+                                                                if (dur.length === 1) {
+                                                                    track['duration'] = parseInt(dur[0]);
+                                                                } else if (dur.length === 2) {
+                                                                    track['duration'] = parseInt(dur[0]) * 60 + parseInt(dur[1]);
+                                                                } else if (dur.length === 3) {
+                                                                    track['duration'] = parseInt(dur[0]) * 3600 + parseInt(dur[1]) * 60 + parseInt(dur[2]);
+                                                                }
+                                                            }
+                                                        } else if (nodeName === "enclosure") {
+                                                            var el = node;
+                                                            for (var l = 0; l < el.attributes.length; l++) {
+                                                                if(el.attributes[l].nodeName === "url")         track['audiourl'] = el.attributes[l].nodeValue;
+                                                            }
+                                                        }
+                                                    } catch(err) {
+                                                        console.debug("Error: " + err.message);
                                                     }
-                                                } catch(err) {
-                                                    console.debug("Error: " + err.message);
-                                                }
                                             }
                                             if (!track.hasOwnProperty("guid")) {
                                                 track['guid'] = track.audiourl;
                                             }
+                                            // Debug: log track data for first few items
+                                            if (j < 3) {
+                                                console.log("[DEBUG] Track " + j + " - name: '" + track.name + "', desc: '" + (track.description || "").substring(0, 30) + "...', guid: " + track.guid);
+                                            }
                                             //do not check every episode in database, just ~11.5 days before last update
                                             if(new Date(rs_timestamp.rows.item(i).lastupdate).getTime()<(track['published']+1000000000))
                                             db.transaction(function(tx2) {
-                                                var ers = tx2.executeSql("SELECT rowid FROM Episode WHERE guid=?", [track.guid]);
+                                                var ers = tx2.executeSql("SELECT rowid, name, description FROM Episode WHERE guid=?", [track.guid]);
                                                 if (ers.rows.length === 0) {
+                                                    console.log("[DEBUG] Inserting episode: " + track.name);
                                                     tx2.executeSql("INSERT INTO Episode(podcast, name, description, audiourl, guid, listened, queued, favourited, duration, published) VALUES(?, ?, ? , ?, ?, ?, ?, ?, ?, ?)", [pid,
                                                                                                                                                                                                                                 track.name,
                                                                                                                                                                                                                                 track.description,
@@ -306,6 +350,15 @@ function updateEpisodes(refreshModel) {
                                                                                                                                                                                                                                 false,
                                                                                                                                                                                                                                 track.duration,
                                                                                                                                                                                                                                 track.published]);
+                                                } else {
+                                                    // Update existing episodes that have missing name or description
+                                                    var existingEp = ers.rows.item(0);
+                                                    if ((!existingEp.name || existingEp.name === "") && track.name) {
+                                                        tx2.executeSql("UPDATE Episode SET name=? WHERE guid=?", [track.name, track.guid]);
+                                                    }
+                                                    if ((!existingEp.description || existingEp.description === "") && track.description) {
+                                                        tx2.executeSql("UPDATE Episode SET description=? WHERE guid=?", [track.description, track.guid]);
+                                                    }
                                                 }
                                             });
                                         }

--- a/app/ui/SearchPage.qml
+++ b/app/ui/SearchPage.qml
@@ -408,9 +408,27 @@ Page {
                     if(e.childNodes[h].nodeName === "channel") {
                         var c = e.childNodes[h];
                         for(var j = 0; j < c.childNodes.length; j++) {
-                            if (c.childNodes[j].nodeName === "description") {
-                                description = c.childNodes[j].childNodes[0].nodeValue
-                                if (description != undefined) {
+                            var node = c.childNodes[j];
+                            var nodeName = (node.localName ? node.localName : node.nodeName).toLowerCase();
+                            // Helper to get text content - iterate all child nodes to find text/CDATA
+                            var getTextContent = function(n) {
+                                var text = "";
+                                if (n.childNodes) {
+                                    for (var m = 0; m < n.childNodes.length; m++) {
+                                        var child = n.childNodes[m];
+                                        // nodeType 3 = TEXT_NODE, nodeType 4 = CDATA_SECTION_NODE
+                                        // Also check nodeName for #text and #cdata-section as fallback
+                                        if (child.nodeType === 3 || child.nodeType === 4 ||
+                                            child.nodeName === "#text" || child.nodeName === "#cdata-section") {
+                                            text += child.nodeValue || "";
+                                        }
+                                    }
+                                }
+                                return text.trim();
+                            };
+                            if (nodeName === "description" || nodeName === "summary" || nodeName === "subtitle") {
+                                description = getTextContent(node);
+                                if (description != undefined && description !== "") {
                                     searchResults.setProperty(index, "description", description)
                                     return
                                 }
@@ -447,12 +465,29 @@ Page {
                 for(var h = 0; h < e.childNodes.length; h++) {
                     if(e.childNodes[h].nodeName === "channel") {
                         var c = e.childNodes[h];
+                        // Helper to get text content - iterate all child nodes to find text/CDATA
+                        var getTextContent = function(n) {
+                            var text = "";
+                            if (n.childNodes) {
+                                for (var m = 0; m < n.childNodes.length; m++) {
+                                    var child = n.childNodes[m];
+                                    // nodeType 3 = TEXT_NODE, nodeType 4 = CDATA_SECTION_NODE
+                                    // Also check nodeName for #text and #cdata-section as fallback
+                                    if (child.nodeType === 3 || child.nodeType === 4 ||
+                                        child.nodeName === "#text" || child.nodeName === "#cdata-section") {
+                                        text += child.nodeValue || "";
+                                    }
+                                }
+                            }
+                            return text.trim();
+                        };
                         for(var j = 0; j < c.childNodes.length; j++) {
-                            var nodeName = c.childNodes[j].nodeName;
-                            if (nodeName === "title")               name = c.childNodes[j].childNodes[0].nodeValue;
-                            else if (nodeName === "author")         artist = c.childNodes[j].childNodes[0].nodeValue;
+                            var node = c.childNodes[j];
+                            var nodeName = (node.localName ? node.localName : node.nodeName).toLowerCase();
+                            if (nodeName === "title")               name = getTextContent(node);
+                            else if (nodeName === "author")         artist = getTextContent(node);
                             else if (nodeName === "image") {
-                                var el = c.childNodes[j];
+                                var el = node;
                                 for (var l = 0; l < el.attributes.length; l++) {
                                     if(el.attributes[l].nodeName === "href")         image = el.attributes[l].nodeValue;
                                 }

--- a/app/ui/SettingsPage.qml
+++ b/app/ui/SettingsPage.qml
@@ -478,9 +478,10 @@ pointing at invalid files have also been cleaned up.")
                     if(e.childNodes[h].nodeName === "channel") {
                         var c = e.childNodes[h];
                         for(var j = 0; j < c.childNodes.length; j++) {
-                            var nodeName = c.childNodes[j].nodeName;
+                            var node = c.childNodes[j];
+                            var nodeName = (node.localName ? node.localName : node.nodeName).toLowerCase();
                             if (nodeName === "image") {
-                                var el = c.childNodes[j];
+                                var el = node;
                                 for (var l = 0; l < el.attributes.length; l++) {
                                     if(el.attributes[l].nodeName === "href") {
                                         coverArt = el.attributes[l].nodeValue;

--- a/po/soy.iko.podphoenix.pot
+++ b/po/soy.iko.podphoenix.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-05 08:26+0000\n"
+"POT-Creation-Date: 2026-01-21 00:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,97 +19,74 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #: ../app/components/TabsList.qml:28 ../app/ui/EpisodesTab.qml:47
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/components/TabsList.qml:28
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:47
 msgid "Episodes"
 msgstr ""
 
 #: ../app/components/TabsList.qml:37 ../app/ui/SearchPage.qml:43
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/components/TabsList.qml:37
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:43
 msgid "Add New Podcasts"
 msgstr ""
 
 #: ../app/components/TabsList.qml:46 ../app/ui/PodcastsTab.qml:40
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/components/TabsList.qml:46
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/PodcastsTab.qml:40
 msgid "Podcasts"
 msgstr ""
 
 #: ../app/components/TabsList.qml:55 ../app/ui/SettingsPage.qml:34
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/components/TabsList.qml:55
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:34
 msgid "Settings"
 msgstr ""
 
 #: ../app/components/Walkthrough.qml:89
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/components/Walkthrough.qml:89
 msgid "Skip"
 msgstr ""
 
-#: ../app/podcasts.js:359
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/podcasts.js:359
+#: ../app/podcasts.js:424
 #, no-c-format, qt-format
 msgid "%1 hr %2 min"
 msgstr ""
 
-#: ../app/podcasts.js:368
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/podcasts.js:368
+#: ../app/podcasts.js:433
 #, no-c-format, qt-format
 msgid "%1 hr"
 msgstr ""
 
-#: ../app/podcasts.js:376
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/podcasts.js:376
+#: ../app/podcasts.js:441
 #, no-c-format, qt-format
 msgid "%1 min"
 msgstr ""
 
 #. TRANSLATORS: About as in information about the app
 #: ../app/settings/About.qml:28 ../app/settings/About.qml:46
-#: ../app/ui/SettingsPage.qml:394
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/About.qml:28
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/About.qml:46
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:394
+#: ../app/ui/SettingsPage.qml:411
 msgid "About"
 msgstr ""
 
 #: ../app/settings/About.qml:46
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/About.qml:46
 msgid "Credits"
 msgstr ""
 
 #. TRANSLATORS: Podphoenix version number e.g Version 0.8
 #: ../app/settings/About.qml:92
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/About.qml:92
 #, qt-format
 msgid "Version %1"
 msgstr ""
 
 #: ../app/settings/About.qml:113
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/About.qml:113
 msgid "Released under the terms of the GNU GPL v3"
 msgstr ""
 
 #: ../app/settings/About.qml:123
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/About.qml:123
 #, qt-format
 msgid "Source code available on %1"
 msgstr ""
 
 #: ../app/settings/CleanSetting.qml:29
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/CleanSetting.qml:29
 msgid "Delete older than"
 msgstr ""
 
 #: ../app/settings/CleanSetting.qml:40 ../app/settings/DownloadSetting.qml:40
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/CleanSetting.qml:40
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/DownloadSetting.qml:40
 msgid "Never"
 msgstr ""
 
 #: ../app/settings/CleanSetting.qml:41
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/CleanSetting.qml:41
 #, qt-format
 msgid "%1 day"
 msgid_plural "%1 days"
@@ -118,9 +95,6 @@ msgstr[1] ""
 
 #: ../app/settings/CleanSetting.qml:42 ../app/settings/CleanSetting.qml:43
 #: ../app/settings/CleanSetting.qml:44
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/CleanSetting.qml:42
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/CleanSetting.qml:43
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/CleanSetting.qml:44
 #, qt-format
 msgid "%1 month"
 msgid_plural "%1 months"
@@ -128,7 +102,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: ../app/settings/CleanSetting.qml:45
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/CleanSetting.qml:45
 #, qt-format
 msgid "%1 year"
 msgid_plural "%1 years"
@@ -137,31 +110,24 @@ msgstr[1] ""
 
 #. TRANSLATORS: The first argument is the name of creator of Podphoenix (Michael Sheldon)
 #: ../app/settings/Credits.qml:31
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/Credits.qml:31
 #, qt-format
 msgid "%1 (Creator)"
 msgstr ""
 
 #: ../app/settings/Credits.qml:31 ../app/settings/Credits.qml:32
 #: ../app/settings/Credits.qml:33
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/Credits.qml:31
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/Credits.qml:32
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/Credits.qml:33
 msgid "Developers"
 msgstr ""
 
 #: ../app/settings/Credits.qml:34
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/Credits.qml:34
 msgid "Designer"
 msgstr ""
 
 #: ../app/settings/Credits.qml:35
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/Credits.qml:35
 msgid "Translators"
 msgstr ""
 
 #: ../app/settings/DownloadSetting.qml:29
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/DownloadSetting.qml:29
 msgid "Download at most"
 msgstr ""
 
@@ -169,10 +135,6 @@ msgstr ""
 #: ../app/settings/DownloadSetting.qml:42
 #: ../app/settings/DownloadSetting.qml:43
 #: ../app/settings/DownloadSetting.qml:44
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/DownloadSetting.qml:41
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/DownloadSetting.qml:42
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/DownloadSetting.qml:43
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/DownloadSetting.qml:44
 #, qt-format
 msgid "%1 episode"
 msgid_plural "%1 episodes"
@@ -180,48 +142,34 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: ../app/settings/ThemeSetting.qml:29 ../app/ui/SettingsPage.qml:181
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/ThemeSetting.qml:29
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:181
 msgid "Theme"
 msgstr ""
 
 #. TRANSLATORS: Light Theme
 #: ../app/settings/ThemeSetting.qml:41 ../app/ui/SettingsPage.qml:182
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/ThemeSetting.qml:41
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:182
 msgid "Light"
 msgstr ""
 
 #. TRANSLATORS: Dark Theme
 #: ../app/settings/ThemeSetting.qml:43 ../app/ui/SettingsPage.qml:182
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/settings/ThemeSetting.qml:43
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:182
 msgid "Dark"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:50
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:50
 msgid "Podcast"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:60 ../app/ui/EpisodesTab.qml:61
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:60
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:61
 msgid "Search Episode"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:68 ../app/ui/EpisodesPage.qml:304
 #: ../app/ui/SearchPage.qml:288
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:68
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:304
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:288
 msgid "Unsubscribe"
 msgstr ""
 
 #. TRANSLATORS: This is the page title. Keep it short. Otherwise it will just be elided.
 #: ../app/ui/EpisodesPage.qml:108 ../app/ui/EpisodesTab.qml:127
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:108
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:127
 #, qt-format
 msgid "%1 item selected"
 msgid_plural "%1 items selected"
@@ -230,55 +178,38 @@ msgstr[1] ""
 
 #: ../app/ui/EpisodesPage.qml:123 ../app/ui/EpisodesTab.qml:142
 #: ../app/ui/NowPlayingPage.qml:42
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:123
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:142
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/NowPlayingPage.qml:42
 msgid "Back"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:135 ../app/ui/EpisodesTab.qml:154
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:135
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:154
 msgid "Mark Listened"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:154 ../app/ui/EpisodesTab.qml:172
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:154
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:172
 msgid "Download episode(s)"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:182 ../app/ui/EpisodesTab.qml:200
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:182
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:200
 msgid "Delete episode(s)"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:205 ../app/ui/EpisodesTab.qml:223
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:205
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:223
 msgid "Favourite episode(s)"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:227 ../app/ui/EpisodesTab.qml:269
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:227
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:269
 msgid "Add to queue"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:256 ../app/ui/EpisodesTab.qml:119
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:256
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:119
 msgid "Search episode"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:301
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:301
 msgid "Unsubscribe Confirmation"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:302
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:302
 #, qt-format
 msgid "Are you sure you want to unsubscribe from <b>%1</b>?"
 msgstr ""
@@ -286,257 +217,198 @@ msgstr ""
 #: ../app/ui/EpisodesPage.qml:321 ../app/ui/SearchPage.qml:143
 #: ../app/ui/SettingsPage.qml:85 ../app/ui/SettingsPage.qml:120
 #: ../app/ui/SettingsPage.qml:155
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:321
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:143
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:85
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:120
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:155
 msgid "Cancel"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:343 ../app/ui/EpisodesTab.qml:406
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:343
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:406
 msgid "Episode Description"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:354 ../app/ui/EpisodesTab.qml:417
-#: ../app/ui/SearchPage.qml:192 ../app/ui/SettingsPage.qml:376
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:354
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:417
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:192
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:376
+#: ../app/ui/SearchPage.qml:192 ../app/ui/SettingsPage.qml:393
 msgid "Close"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:382
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:382
 msgid "No episodes found"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:383
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:383
 msgid "No episodes found matching the search term."
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:500
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:500
 msgid "Unheard"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:517
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:517
 msgid "Listened"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:536
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:536
 msgid "Downloaded"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:603
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:603
 msgid "Mark as unheard"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:603
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:603
 msgid "Mark as listened"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:619
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:619
 msgid "Delete downloaded file"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:619
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:619
 msgid "Queued"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:619
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:619
 msgid "Download"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:644
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:644
 msgid "Add to playlist"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:653
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:653
 msgid "Unfavourite"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:653
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:653
 msgid "Favourite"
 msgstr ""
 
 #: ../app/ui/EpisodesPage.qml:668
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesPage.qml:668
 msgid "Show episode description"
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:81
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:81
 msgid "Recent"
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:81
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:81
 msgid "Downloads"
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:81
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:81
 msgid "Favourites"
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:246
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:246
 msgid "Unfavourite episode(s)"
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:309
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:309
 msgid "No New Episodes"
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:311
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:311
 msgid "No Downloaded Episodes"
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:313
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:313
 msgid "No Favourited Episodes"
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:315
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:315
 msgid "No Episodes Found"
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:321
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:321
 msgid "No more episodes to listen to!"
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:323
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:323
 msgid "No episodes have been downloaded for offline listening"
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:325
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:325
 msgid "No episodes have been favourited."
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:327
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:327
 msgid "No Episodes found matching the search term."
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:456
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:456
 msgid "Downloads in progress"
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:496
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:496
 msgid "Downloaded episodes"
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:506
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:506
 msgid "Today"
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:510
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:510
 msgid "Yesterday"
 msgstr ""
 
 #: ../app/ui/EpisodesTab.qml:514
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/EpisodesTab.qml:514
 msgid "Older"
 msgstr ""
 
 #. TRANSLATORS: The string shown in the UI is -15s to denote the number of seconds that the podcast playback will skip backward.
 #: ../app/ui/FullPlayingView.qml:241
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/FullPlayingView.qml:241
 #, no-c-format, qt-format
 msgid "-%1s"
 msgstr ""
 
 #. TRANSLATORS: The string shown in the UI is +15s to denote the number of seconds that the podcast playback will skip forward.
 #: ../app/ui/FullPlayingView.qml:302
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/FullPlayingView.qml:302
 #, no-c-format, qt-format
 msgid "+%1s"
 msgstr ""
 
 #: ../app/ui/ImportPage.qml:18
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/ImportPage.qml:18
 msgid "Choose"
 msgstr ""
 
 #: ../app/ui/NowPlayingPage.qml:34
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/NowPlayingPage.qml:34
 msgid "Now Playing"
 msgstr ""
 
 #: ../app/ui/NowPlayingPage.qml:73
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/NowPlayingPage.qml:73
 msgid "Full view"
 msgstr ""
 
 #: ../app/ui/NowPlayingPage.qml:73
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/NowPlayingPage.qml:73
 msgid "Queue"
 msgstr ""
 
 #: ../app/ui/PodcastsTab.qml:55 ../app/ui/SearchPage.qml:57
 #: ../app/ui/SearchPage.qml:174
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/PodcastsTab.qml:55
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:57
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:174
 msgid "Search Podcast"
 msgstr ""
 
 #: ../app/ui/PodcastsTab.qml:95
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/PodcastsTab.qml:95
 msgid "Search podcast"
 msgstr ""
 
 #: ../app/ui/PodcastsTab.qml:125
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/PodcastsTab.qml:125
 msgid "No Podcast Subscriptions"
 msgstr ""
 
 #: ../app/ui/PodcastsTab.qml:125 ../app/ui/SearchPage.qml:220
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/PodcastsTab.qml:125
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:220
 msgid "No Podcasts Found"
 msgstr ""
 
 #: ../app/ui/PodcastsTab.qml:126
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/PodcastsTab.qml:126
 msgid ""
 "You haven't subscribed to any podcasts yet, visit the 'Add New Podcasts' "
 "page to add some."
 msgstr ""
 
 #: ../app/ui/PodcastsTab.qml:127 ../app/ui/SearchPage.qml:222
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/PodcastsTab.qml:127
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:222
 msgid "No podcasts found matching the search term."
 msgstr ""
 
 #: ../app/ui/PodcastsTab.qml:213
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/PodcastsTab.qml:213
 #, qt-format
 msgid "%1 unheard episode"
 msgid_plural "%1 unheard episodes"
@@ -544,55 +416,45 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: ../app/ui/SearchPage.qml:65
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:65
 msgid "Add Podcast"
 msgstr ""
 
 #: ../app/ui/SearchPage.qml:73
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:73
 msgid "Import Podcasts"
 msgstr ""
 
 #: ../app/ui/SearchPage.qml:135
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:135
 msgid "Save Podcast"
 msgstr ""
 
 #: ../app/ui/SearchPage.qml:162
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:162
 msgid "Feed URL"
 msgstr ""
 
 #: ../app/ui/SearchPage.qml:189
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:189
 msgid "Unable to subscribe"
 msgstr ""
 
 #: ../app/ui/SearchPage.qml:190
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:190
 msgid "Please check the URL and try again"
 msgstr ""
 
 #: ../app/ui/SearchPage.qml:220
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:220
 msgid "Looking to add a new podcast?"
 msgstr ""
 
 #: ../app/ui/SearchPage.qml:221
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:221
 msgid ""
 "Click the 'magnifier' at the top to search or the 'plus' button to add by URL"
 msgstr ""
 
 #: ../app/ui/SearchPage.qml:288
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:288
 msgid "Subscribe"
 msgstr ""
 
 #. TRANSLATORS: The first argument here is the date of when the podcast was last updated followed by
 #. the podcast description.
 #: ../app/ui/SearchPage.qml:326
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:326
 #, qt-format
 msgid ""
 "Last Updated: %1\n"
@@ -600,70 +462,51 @@ msgid ""
 msgstr ""
 
 #: ../app/ui/SearchPage.qml:383
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:383
 msgid "Not Available"
 msgstr ""
 
-#: ../app/ui/SearchPage.qml:499
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:499
+#: ../app/ui/SearchPage.qml:543
 msgid "Please wait"
 msgstr ""
 
-#: ../app/ui/SearchPage.qml:500
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:500
+#: ../app/ui/SearchPage.qml:544
 msgid "Importing podcasts..."
 msgstr ""
 
-#: ../app/ui/SearchPage.qml:518
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SearchPage.qml:518
+#: ../app/ui/SearchPage.qml:562
 msgid "imported"
 msgstr ""
 
 #. TRANSLATORS: This strings refers to the seeking of the episode playback. Users can set how far they
 #. want to seek forward when pressing on this button.
 #: ../app/ui/SettingsPage.qml:65 ../app/ui/SettingsPage.qml:206
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:65
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:206
 msgid "Skip forward"
 msgstr ""
 
 #: ../app/ui/SettingsPage.qml:72 ../app/ui/SettingsPage.qml:107
 #: ../app/ui/SettingsPage.qml:207 ../app/ui/SettingsPage.qml:214
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:72
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:107
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:207
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:214
 #, qt-format
 msgid "%1 seconds"
 msgstr ""
 
 #: ../app/ui/SettingsPage.qml:77 ../app/ui/SettingsPage.qml:112
 #: ../app/ui/SettingsPage.qml:147
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:77
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:112
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:147
 msgid "OK"
 msgstr ""
 
 #. TRANSLATORS: This strings refers to the seeking of the episode playback. Users can set how far they
 #. want to seek backward when pressing on this button.
 #: ../app/ui/SettingsPage.qml:100 ../app/ui/SettingsPage.qml:213
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:100
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:213
 msgid "Skip back"
 msgstr ""
 
 #. TRANSLATORS: This strings refers to refreshing podcasts. Users can set how often they
 #. want to check for new episodes.
 #: ../app/ui/SettingsPage.qml:135 ../app/ui/SettingsPage.qml:238
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:135
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:238
 msgid "Refresh podcasts after"
 msgstr ""
 
 #: ../app/ui/SettingsPage.qml:142 ../app/ui/SettingsPage.qml:239
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:142
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:239
 #, qt-format
 msgid "%1 hours"
 msgstr ""
@@ -671,105 +514,93 @@ msgstr ""
 #. TRANSLATORS: Shortened form of "Miscellaneous" which is shown to denote other setting options
 #. that doesn't fit into any other category.
 #: ../app/ui/SettingsPage.qml:176
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:176
 msgid "General Settings"
 msgstr ""
 
 #: ../app/ui/SettingsPage.qml:189
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:189
 msgid "Displays podcasts in a list view"
 msgstr ""
 
 #: ../app/ui/SettingsPage.qml:201
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:201
 msgid "Playback Settings"
 msgstr ""
 
 #: ../app/ui/SettingsPage.qml:221
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:221
 msgid "Continue where stopped"
 msgstr ""
 
 #: ../app/ui/SettingsPage.qml:233
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:233
 msgid "Podcast Episode Settings"
 msgstr ""
 
 #: ../app/ui/SettingsPage.qml:246
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:246
 msgid "Automatically delete old episodes"
 msgstr ""
 
 #: ../app/ui/SettingsPage.qml:248
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:248
 msgid ""
 "Delete episodes that are older than a given number of days for each podcast"
 msgstr ""
 
 #: ../app/ui/SettingsPage.qml:260
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:260
 msgid "Automatically download new episodes"
 msgstr ""
 
 #: ../app/ui/SettingsPage.qml:262
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:262
 msgid "Default number of new episodes to download for each podcast"
 msgstr ""
 
 #: ../app/ui/SettingsPage.qml:274
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:274
-msgid "Only download over WiFi"
+msgid "Automatically delete listened episodes"
 msgstr ""
 
 #: ../app/ui/SettingsPage.qml:276
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:276
+msgid "Automatically delete listened episodes on application start"
+msgstr ""
+
+#: ../app/ui/SettingsPage.qml:291
+msgid "Only download over WiFi"
+msgstr ""
+
+#: ../app/ui/SettingsPage.qml:293
 msgid "Download episodes only when the device is using WiFi"
 msgstr ""
 
-#: ../app/ui/SettingsPage.qml:296
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:296
+#: ../app/ui/SettingsPage.qml:313
 msgid "Refresh podcast artwork"
 msgstr ""
 
-#: ../app/ui/SettingsPage.qml:298
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:298
+#: ../app/ui/SettingsPage.qml:315
 msgid "Update all podcasts artwork and fix missing ones"
 msgstr ""
 
-#: ../app/ui/SettingsPage.qml:327
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:327
+#: ../app/ui/SettingsPage.qml:344
 msgid "Storage Settings"
 msgstr ""
 
-#: ../app/ui/SettingsPage.qml:338
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:338
+#: ../app/ui/SettingsPage.qml:355
 msgid "Delete orphaned files and links"
 msgstr ""
 
-#: ../app/ui/SettingsPage.qml:340
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:340
+#: ../app/ui/SettingsPage.qml:357
 msgid "Free space by removing orphaned downloaded files and links"
 msgstr ""
 
-#: ../app/ui/SettingsPage.qml:370
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:370
+#: ../app/ui/SettingsPage.qml:387
 msgid "Removed orphaned files and links"
 msgstr ""
 
-#: ../app/ui/SettingsPage.qml:370
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:370
+#: ../app/ui/SettingsPage.qml:387
 msgid "No orphans found!"
 msgstr ""
 
-#: ../app/ui/SettingsPage.qml:371
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:371
+#: ../app/ui/SettingsPage.qml:388
 msgid ""
 "All orphaned files have been deleted to recover disk space. Orphaned links "
 "pointing at invalid files have also been cleaned up."
 msgstr ""
 
-#: ../app/ui/SettingsPage.qml:373
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:373
+#: ../app/ui/SettingsPage.qml:390
 msgid ""
 "No orphaned files have been found to recover disk space. Podphoenix database "
 "is clean."
@@ -777,23 +608,19 @@ msgstr ""
 
 #. TRANSLATORS: Shortened form of "Miscellaneous" which is shown to denote other setting options
 #. that doesn't fit into any other category.
-#: ../app/ui/SettingsPage.qml:388
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:388
+#: ../app/ui/SettingsPage.qml:405
 msgid "Misc."
 msgstr ""
 
-#: ../app/ui/SettingsPage.qml:404
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/ui/SettingsPage.qml:404
+#: ../app/ui/SettingsPage.qml:421
 msgid "Report Bug"
 msgstr ""
 
 #: ../app/welcomewizard/Slide1.qml:42
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/welcomewizard/Slide1.qml:42
 msgid "Welcome to Podphoenix"
 msgstr ""
 
 #: ../app/welcomewizard/Slide1.qml:53
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/welcomewizard/Slide1.qml:53
 msgid ""
 "Enjoy your favourite shows with Podphoenix, the chirpiest podcast manager "
 "for Ubuntu.\n"
@@ -802,29 +629,24 @@ msgid ""
 msgstr ""
 
 #: ../app/welcomewizard/Slide1.qml:82
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/welcomewizard/Slide1.qml:82
 msgid "Swipe to move between pages"
 msgstr ""
 
 #: ../app/welcomewizard/Slide2.qml:45
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/welcomewizard/Slide2.qml:45
 msgid "Discover New Podcasts"
 msgstr ""
 
 #: ../app/welcomewizard/Slide2.qml:62
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/welcomewizard/Slide2.qml:62
 msgid ""
 "Podphoenix uses the iTunes® database to provide access to a huge collection "
 "of podcasts. You can also add podcasts by their URL."
 msgstr ""
 
 #: ../app/welcomewizard/Slide3.qml:45
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/welcomewizard/Slide3.qml:45
 msgid "Smart Settings"
 msgstr ""
 
 #: ../app/welcomewizard/Slide3.qml:62
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/welcomewizard/Slide3.qml:62
 msgid ""
 "Podphoenix can optionally download new episodes and clean up old episodes "
 "automatically, this can be enabled from the settings page."
@@ -834,12 +656,10 @@ msgstr ""
 #. For instance, if the app was in english, then it is appropriate to set this string as
 #. Hallo or Bonjour etc to symbolize the internationalization feature in podphoenix.
 #: ../app/welcomewizard/Slide4.qml:48
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/welcomewizard/Slide4.qml:48
 msgid "Hallo! Bonjour!"
 msgstr ""
 
 #: ../app/welcomewizard/Slide4.qml:67
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/welcomewizard/Slide4.qml:67
 #, qt-format
 msgid ""
 "Podphoenix is available in over 15 languages and is translated by the %1 "
@@ -847,12 +667,10 @@ msgid ""
 msgstr ""
 
 #: ../app/welcomewizard/Slide5.qml:45
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/welcomewizard/Slide5.qml:45
 msgid "Touch Gestures"
 msgstr ""
 
 #: ../app/welcomewizard/Slide5.qml:64
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/welcomewizard/Slide5.qml:64
 msgid ""
 "Episodes can be swiped left to reveal more actions (or right click if you're "
 "using a mouse). You can also multi-select them by long-pressing on an "
@@ -860,13 +678,11 @@ msgid ""
 msgstr ""
 
 #: ../app/welcomewizard/Slide6.qml:45
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/welcomewizard/Slide6.qml:45
 msgid "Support"
 msgstr ""
 
 #. TRANSLATORS: The %1 points to a url defined in html format <a href=\link\>Link</a>.
 #: ../app/welcomewizard/Slide6.qml:65
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/welcomewizard/Slide6.qml:65
 #, qt-format
 msgid ""
 "If you find any bugs or have any feature requests, let us know on our "
@@ -874,28 +690,23 @@ msgid ""
 msgstr ""
 
 #: ../app/welcomewizard/Slide7.qml:45
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/welcomewizard/Slide7.qml:45
 msgid "Enjoy"
 msgstr ""
 
 #: ../app/welcomewizard/Slide7.qml:62
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/welcomewizard/Slide7.qml:62
 msgid "We hope you enjoy using Podphoenix!"
 msgstr ""
 
 #: ../app/welcomewizard/Slide7.qml:75
-#: ../build/x86_64-linux-gnu/app/install/share/qml/podphoenix/welcomewizard/Slide7.qml:75
 msgid "Finish"
 msgstr ""
 
 #: ../build/aarch64-linux-gnu/app/po/Podphoenix.desktop.in.h:1
-#: ../build/x86_64-linux-gnu/app/po/Podphoenix.desktop.in.h:1
-#: /home/iko/Developer/podphoenix/build/aarch64-linux-gnu/app/po/Podphoenix.desktop.in.h:1
+#: /home/phablet/Documents/podphoenix/build/aarch64-linux-gnu/app/po/Podphoenix.desktop.in.h:1
 msgid "The chirpiest podcast manager for Ubuntu"
 msgstr ""
 
 #: ../build/aarch64-linux-gnu/app/po/Podphoenix.desktop.in.h:2
-#: ../build/x86_64-linux-gnu/app/po/Podphoenix.desktop.in.h:2
-#: /home/iko/Developer/podphoenix/build/aarch64-linux-gnu/app/po/Podphoenix.desktop.in.h:2
+#: /home/phablet/Documents/podphoenix/build/aarch64-linux-gnu/app/po/Podphoenix.desktop.in.h:2
 msgid "podcast;audio;itunes;broadcast;digital;stream;podcatcher;video;vodcast;"
 msgstr ""


### PR DESCRIPTION
This will reliably guarantee that podcasts with episodes which previously didn't have the episode names and info available now will, with more robust node parsing.

Before:

![photo_2026-02-03_02-24-46](https://github.com/user-attachments/assets/7d85b93c-72dc-4205-bce3-9ea3061c6760)
![photo_2026-02-03_02-24-55](https://github.com/user-attachments/assets/3e229af0-8932-48c8-a40c-0704748fe006)

After:

![photo_2026-02-03_02-28-25](https://github.com/user-attachments/assets/c1dfdeea-ecd9-4b11-a2d8-4e7ff7b595ef)
![photo_2026-02-03_02-28-35](https://github.com/user-attachments/assets/c234bb72-2021-4d34-9d03-5f1bb44878a1)
